### PR TITLE
[SW-88499] hlml: add support for device module_id

### DIFF
--- a/hlml.go
+++ b/hlml.go
@@ -337,6 +337,13 @@ func (d Device) SerialNumber() (string, error) {
 	return C.GoString(&serial[0]), errorString(rc)
 }
 
+// ModuleID returns the device moduleID
+func (d Device) ModuleID() (uint, error) {
+	var moduleID C.uint
+	rc := C.hlml_device_get_module_id(d.dev, &moduleID)
+	return uint(moduleID), errorString(rc)
+}
+
 // BoardID returns an ID for the PCB board
 func (d Device) BoardID() (uint, error) {
 	var id C.uint

--- a/hlml_test.go
+++ b/hlml_test.go
@@ -170,6 +170,19 @@ func TestGetDeviceName(t *testing.T) {
 	assert.Nil(t, err, err)
 }
 
+func TestDeviceModuleID(t *testing.T) {
+	dev := prepareDevice(t)
+
+	start := time.Now()
+	moduleID, err := dev.ModuleID()
+	printDuration("ModuleID()", time.Since(start))
+	assert.Nil(t, err, "Should be able to get moduleID")
+	// We assume we have max of 8 cards with moduleID: 0,1,2,3,4,5,6,7
+	assert.GreaterOrEqual(t, moduleID, uint(0), "ModuleID should be Greater or equal than 0")
+	err = Shutdown()
+	assert.Nil(t, err, err)
+}
+
 func TestPCIFunctions(t *testing.T) {
 	err := Initialize()
 	assert.Nil(t, err, err)


### PR DESCRIPTION
- add moduleID API to provide support for TF on k8s env.